### PR TITLE
Correct error in docker.md

### DIFF
--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -234,8 +234,8 @@ FROM nodered/node-red
 
 # Copy package.json to the WORKDIR so npm builds all
 # of your added nodes modules for Node-RED
-COPY package.json .
-RUN npm install --unsafe-perm --no-update-notifier --no-fund --only=production
+COPY package.json /data/package.json
+RUN cd /data && npm install --unsafe-perm --no-update-notifier --no-fund --only=production
 
 # Copy _your_ Node-RED project files into place
 # NOTE: This will only work if you DO NOT later mount /data as an external volume.
@@ -289,6 +289,8 @@ To _run_ locally for development where changes are written immediately and only 
 ```bash
 docker run --rm -e "NODE_RED_CREDENTIAL_SECRET=your_secret_goes_here" -p 1880:1880 -v `pwd`:/data --name a-container-name your-image-name
 ```
+
+**NOTE:** If using the above command, ensure that your local directory does **not** contain a `node_modules` directory as that local directory will supersede the one that Docker built for you, possibly causing problems.
 
 ### Startup
 


### PR DESCRIPTION
Correcting an error in a Dockerfile example, and adding a caution to a `docker run` command.

From the Slack conversation:

> The `COPY package.json .` line is wrong. If that file _has_ a dependency on `node-red`, then like @hardillb said, it kind of defeats the point of the `FROM .`, And if it _doesn’t have_ a reference to `node-red`, Node-RED is removed.
> 
> And then there needs to be a caveat for the later `pwd` (directory cannot contain a node_modules directory).